### PR TITLE
Add support for zip files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtualenv'
+          command: |
+            virtualenv -p python3 /usr/local/share/virtualenvs/singer-encodings
+            source /usr/local/share/virtualenvs/singer-encodings/bin/activate
+            pip install .[dev]
+      - run:
+          name: 'Unit tests'
+          command: |
+            nosetests
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - run:
           name: 'Unit tests'
           command: |
+            source /usr/local/share/virtualenvs/singer-encodings/bin/activate
             nosetests
 
 workflows:

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,8 @@ setup(name="singer-encodings",
       url="http://singer.io",
       install_requires=[
       ],
+      extras_require={
+          "dev": ["nose"]
+      },
       packages=find_packages(),
 )

--- a/singer_encodings/compression.py
+++ b/singer_encodings/compression.py
@@ -1,4 +1,5 @@
 import gzip
+import zipfile
 
 def infer(iterable, file_name):
     """Uses the incoming file_name and checks the end of the string
@@ -8,7 +9,11 @@ def infer(iterable, file_name):
 
     if file_name.endswith('.tar.gz'):
         raise NotImplementedError("tar.gz not supported")
-    elif file_name.endswith(".gz"):
+    elif file_name.endswith('.gz'):
         yield gzip.GzipFile(fileobj=iterable)
+    elif file_name.endswith('.zip'):
+        with zipfile.ZipFile(iterable) as zip:
+            for name in zip.namelist():
+                yield zip.open(name)
     else:
         yield iterable


### PR DESCRIPTION
# Description of change
 Add support for zip files. Currently this will only be used by `tap-sftp`

# Manual QA Steps
- Ran this with `tap-sftp` and it successfully read zip files
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
