### PR TITLE
Don't log data if the id or date_overrides don't match

### DIFF
--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -28,13 +28,13 @@ def get_row_iterator(iterable, options=None):
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):
-            raise Exception('CSV file missing required headers: {}, file only contains headers for fields: {}'
-                            .format(key_properties - headers, headers))
+            raise Exception('CSV file missing required headers: {}'
+                            .format(key_properties - headers))
 
     if options.get('date_overrides'):
         date_overrides = set(options['date_overrides'])
         if not date_overrides.issubset(headers):
-            raise Exception('CSV file missing date_overrides headers: {}, file only contains headers for fields: {}'
-                            .format(date_overrides - headers, headers))
+            raise Exception('CSV file missing date_overrides headers: {}'
+                            .format(date_overrides - headers))
     return reader
 


### PR DESCRIPTION
# Description of change
Don't log the fieldnames in the case where they might be actual data.

# Manual QA steps
 - 
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
