### PR TITLE
json_schema needs to account for delimiter

### DIFF
--- a/singer_encodings/json_schema.py
+++ b/singer_encodings/json_schema.py
@@ -37,6 +37,7 @@ def sample_file(conn, table_spec, f, sample_rate, max_records):
 
     # Add file_name to opts and flag infer_compression to support gzipped files
     opts = {'key_properties': table_spec['key_properties'],
+            'delimiter': table_spec['delimiter'],
             'file_name': f['filepath']}
 
     readers = csv.get_row_iterators(file_handle, options=opts, infer_compression=True)


### PR DESCRIPTION
# Description of change

The table_spec is missing the delimited in the options dict which is needed for any delimiter other than `,`

# Manual QA steps
 - Tested with `\t` as a delimited to ensure it passed through and worked.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
