### PR TITLE
Tdl 12464 code enhancement to handle duplicate headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:
@@ -15,6 +15,7 @@ jobs:
           name: 'Unit tests'
           command: |
             source /usr/local/share/virtualenvs/singer-encodings/bin/activate
+            pip install .[dev]
             nosetests
 
 workflows:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name="singer-encodings",
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       url="http://singer.io",
       install_requires=[
+          "singer-python"
       ],
       extras_require={
           "dev": ["nose"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-encodings",
-      version='0.0.8',
+      version='0.0.9',
       description="Singer.io encodings library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -1,10 +1,8 @@
 import codecs
 import csv
-from singer_encodings.csv_helper import CSVHelper
+from singer_encodings.csv_helper import (CSVHelper, SDC_EXTRA_COLUMN)
 
 from . import compression
-
-SDC_EXTRA_COLUMN = "_sdc_extra"
 
 def get_row_iterators(iterable, options={}, infer_compression=False):
     """Accepts an interable, options and a flag to infer compression and yields

--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -1,5 +1,6 @@
 import codecs
 import csv
+from singer_encodings.csv_helper import CSVHelper
 
 from . import compression
 
@@ -14,17 +15,31 @@ def get_row_iterators(iterable, options={}, infer_compression=False):
     for item in compressed_iterables:
         yield get_row_iterator(item, options=options)
 
-def get_row_iterator(iterable, options=None):
-    """Accepts an interable, options and returns a csv.DictReader object
-    which can be used to yield CSV rows."""
+def get_row_iterator(iterable, options=None, headers_in_catalog = None, with_duplicate_headers = False):
+    """Accepts an interable, options and returns a csv.DictReader or csv.Reader object
+    which can be used to yield CSV rows.
+    When with_duplicate_headers == true, it will return csv.Reader object
+    When with_duplicate_headers == false, it will return csv.DictReader object (default)
+    """
+
     options = options or {}
-
+    reader = []
+    headers = set()
     file_stream = codecs.iterdecode(iterable, encoding='utf-8')
+    delimiter = options.get('delimiter', ',')
 
-    # Replace any NULL bytes in the line given to the DictReader
-    reader = csv.DictReader((line.replace('\0', '') for line in file_stream), fieldnames=None, restkey=SDC_EXTRA_COLUMN, delimiter=options.get('delimiter', ','))
+    # Return the CSV key-values along with considering the duplicate headers, if any, in the CSV file
+    if with_duplicate_headers:
+        # CSV Helper is used to handle duplicate headers.
+        # It will store the duplicate headers and its value in the '_sdc_extra' field
+        csv_helper = CSVHelper()
+        reader = csv_helper.get_row_iterator(file_stream, delimiter, headers_in_catalog)
+        headers = csv_helper.unique_headers
+    else :
+        # Replace any NULL bytes in the line given to the DictReader
+        reader = csv.DictReader((line.replace('\0', '') for line in file_stream), fieldnames=None, restkey=SDC_EXTRA_COLUMN, delimiter=delimiter)
+        headers = set(reader.fieldnames)
 
-    headers = set(reader.fieldnames)
     if options.get('key_properties'):
         key_properties = set(options['key_properties'])
         if not key_properties.issubset(headers):
@@ -37,4 +52,3 @@ def get_row_iterator(iterable, options=None):
             raise Exception('CSV file missing date_overrides headers: {}'
                             .format(date_overrides - headers))
     return reader
-

--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -32,7 +32,7 @@ def get_row_iterator(iterable, options=None, headers_in_catalog = None, with_dup
         # It will store the duplicate headers and its value in the '_sdc_extra' field
         csv_helper = CSVHelper()
         reader = csv_helper.get_row_iterator(file_stream, delimiter, headers_in_catalog)
-        headers = csv_helper.unique_headers
+        headers = set(csv_helper.unique_headers)
     else :
         # Replace any NULL bytes in the line given to the DictReader
         reader = csv.DictReader((line.replace('\0', '') for line in file_stream), fieldnames=None, restkey=SDC_EXTRA_COLUMN, delimiter=delimiter)

--- a/singer_encodings/csv_helper.py
+++ b/singer_encodings/csv_helper.py
@@ -1,12 +1,10 @@
 import csv
-import json
 import singer
-
-LOGGER = singer.get_logger()
 
 SDC_EXTRA_COLUMN = "_sdc_extra"
 NO_HEADERS = "no_headers"
 
+LOGGER = singer.get_logger()
 
 class CSVHelper:
     """
@@ -78,7 +76,7 @@ class CSVHelper:
 
                 # If number of values provided in the row are greater than CSV headers
                 else:
-                    sdc_extra_values.append(json.dumps({ NO_HEADERS : row[all_csv_headers_length:] }))
+                    sdc_extra_values.append({ NO_HEADERS : row[all_csv_headers_length:] })
 
                 # Fetching the values of only unique headers
                 row_dict = dict(zip(self.unique_headers, map(row.__getitem__, new_unique_headers_idxs)))
@@ -93,7 +91,7 @@ class CSVHelper:
                 dup_dictionary = self.generate_dict_from_zipped_data(dup_zipped)
 
                 # Adding dictionary of duplicate header,values in _sdc_extra field as string
-                sdc_extra_values.extend([json.dumps({dup_head : dup_val}) for dup_head, dup_val in dup_dictionary.items()])
+                sdc_extra_values.extend([{dup_head : dup_val} for dup_head, dup_val in dup_dictionary.items()])
 
                 if len(sdc_extra_values) > 0:
                     row_dict.update({ SDC_EXTRA_COLUMN : sdc_extra_values})
@@ -105,7 +103,7 @@ class CSVHelper:
                     row_dict = dict(zip(self.all_csv_headers, row[0:len(self.unique_headers)]))
 
                     # Adding extra column values in _sdc_extra key
-                    row_dict.update({ SDC_EXTRA_COLUMN : [json.dumps({ NO_HEADERS : row[len(self.unique_headers):] })] })
+                    row_dict.update({ SDC_EXTRA_COLUMN : [{ NO_HEADERS : row[len(self.unique_headers):] }] })
 
                 else:
                     row_dict = dict(zip(self.all_csv_headers, row))
@@ -127,9 +125,9 @@ class CSVHelper:
             not_in_catalog = headers_in_catalog and header not in headers_in_catalog
             if header in self.unique_headers or not_in_catalog:
 
-                # check whether header is not in catalog and it is not already in duplicate headers list
+                 # check whether header is not in catalog and it is not already in duplicate headers list
                 if not_in_catalog and header not in self.duplicate_headers:
-                    LOGGER.debug("\"%s\" field is not found in catalog and its value will be stored in the \"_sdc_extra\" field.",header)
+                    LOGGER.warn("\"%s\" field is not found in catalog and its value will be stored in the \"_sdc_extra\" field.",header)
 
                 self.duplicate_headers.append(header)
                 self.dup_headers_idxs.append(header_index)
@@ -137,6 +135,7 @@ class CSVHelper:
                 self.unique_headers.append(header)
                 self.unique_headers_idxs.append(header_index)
             header_index += 1
+
 
         # Check whether duplicate headers are present or not
         if len(self.dup_headers_idxs) > 0:

--- a/singer_encodings/csv_helper.py
+++ b/singer_encodings/csv_helper.py
@@ -1,0 +1,147 @@
+import csv
+import json
+import singer
+
+LOGGER = singer.get_logger()
+
+SDC_EXTRA_COLUMN = "_sdc_extra"
+NO_HEADERS = "no_headers"
+
+
+class CSVHelper:
+    """
+        CSV Helper class to read the CSV with duplicate headers too.
+    """
+
+    def __init__(self):
+        self.all_csv_headers = []
+        self.unique_headers = []
+        self.unique_headers_idxs = []
+        self.duplicate_headers = []
+        self.dup_headers_idxs = []
+
+
+    @staticmethod
+    def generate_dict_from_zipped_data(zipped_data):
+        """
+        Generate dictionary from zipped data.
+        If same key exist multiple time it will store the value in list.
+            e.g.: 1. {'key': 'value'}
+                  2. {'key': ['value1', 'value2']}
+
+        Args:
+            zipped_data zip(): Zipped Data
+                e.g. ('key','value')
+
+        Returns:
+            dict() : Dictionary of Zipped Data
+        """
+        dup_dictionary = {}
+
+        for key, value in zipped_data:
+            if key in dup_dictionary:
+                # Check the type of value of dictionary whether it list
+                if not isinstance(dup_dictionary[key], list):
+                    dup_dictionary[key] = [dup_dictionary[key], value]
+                else:
+                    dup_dictionary[key].append(value)
+            else:
+                dup_dictionary[key] = value
+
+        return dup_dictionary
+
+
+    def __generate_dict_reader(self, csv_reader):
+        """
+        Generate dictionary from CSV reader object
+
+        Args:
+            csv_reader csv.Reader() : Reader object of CSV
+        Return:
+            yield row
+        """
+
+        for row in csv_reader:
+            row_dict = {}
+            row_length = len(row)
+            all_csv_headers_length = len(self.all_csv_headers)
+            sdc_extra_values = []
+
+            if len(self.dup_headers_idxs) > 0:
+                new_unique_headers_idxs = self.unique_headers_idxs
+                new_dup_headers_idxs = self.dup_headers_idxs
+
+                # If number of values provided in the row are lesser than or equal to CSV headers count
+                if row_length <= all_csv_headers_length:
+                    new_unique_headers_idxs = [index for index in self.unique_headers_idxs if index < row_length]
+                    new_dup_headers_idxs = [index for index in self.dup_headers_idxs if index < row_length]
+
+                # If number of values provided in the row are greater than CSV headers
+                else:
+                    sdc_extra_values.append(json.dumps({ NO_HEADERS : row[all_csv_headers_length:] }))
+
+                # Fetching the values of only unique headers
+                row_dict = dict(zip(self.unique_headers, map(row.__getitem__, new_unique_headers_idxs)))
+
+                # Fetching the values of duplicate headers
+                dup_headers_values = list(map(row.__getitem__, new_dup_headers_idxs))
+
+                # Generate zip for duplicate headers and its values
+                dup_zipped = zip(self.duplicate_headers, dup_headers_values)
+
+                # Get the dictionary from zipped data
+                dup_dictionary = self.generate_dict_from_zipped_data(dup_zipped)
+
+                # Adding dictionary of duplicate header,values in _sdc_extra field as string
+                sdc_extra_values.extend([json.dumps({dup_head : dup_val}) for dup_head, dup_val in dup_dictionary.items()])
+
+                if len(sdc_extra_values) > 0:
+                    row_dict.update({ SDC_EXTRA_COLUMN : sdc_extra_values})
+
+            else:
+
+                # If row contains more values than number of headers
+                if row_length > all_csv_headers_length:
+                    row_dict = dict(zip(self.all_csv_headers, row[0:len(self.unique_headers)]))
+
+                    # Adding extra column values in _sdc_extra key
+                    row_dict.update({ SDC_EXTRA_COLUMN : [json.dumps({ NO_HEADERS : row[len(self.unique_headers):] })] })
+
+                else:
+                    row_dict = dict(zip(self.all_csv_headers, row))
+
+            yield row_dict
+
+
+    def get_row_iterator(self, file_stream, delimiter, headers_in_catalog = None):
+        """Accepts a file_stream, delimiter and the headers available in catalog. It returns a csv.Reader object
+        which can be used to yield CSV rows."""
+
+        # Replace any NULL bytes in the line given to the Reader
+        reader = csv.reader((line.replace('\0', '') for line in file_stream), delimiter=delimiter)
+        self.all_csv_headers = next(reader)
+        header_index = 0
+
+        for header in self.all_csv_headers:
+            # Checking if the header is present in the headers_in_catalog
+            not_in_catalog = headers_in_catalog and header not in headers_in_catalog
+            if header in self.unique_headers or not_in_catalog:
+
+                # check whether header is not in catalog and it is not already in duplicate headers list
+                if not_in_catalog and header not in self.duplicate_headers:
+                    LOGGER.debug("\"%s\" field is not found in catalog and its value will be stored in the \"_sdc_extra\" field.",header)
+
+                self.duplicate_headers.append(header)
+                self.dup_headers_idxs.append(header_index)
+            else:
+                self.unique_headers.append(header)
+                self.unique_headers_idxs.append(header_index)
+            header_index += 1
+
+        # Check whether duplicate headers are present or not
+        if len(self.dup_headers_idxs) > 0:
+            # Get the unique names of duplicate headers
+            dup_headers = set(map(self.all_csv_headers.__getitem__, self.dup_headers_idxs))
+            LOGGER.warn("Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.",dup_headers)
+
+        return self.__generate_dict_reader(reader)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -10,7 +10,7 @@ class TestRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], ['4'])
+        self.assertEquals(rows[0]['_sdc_extra'], ['4'])
 
 class TestNullBytes(unittest.TestCase):
 
@@ -19,7 +19,7 @@ class TestNullBytes(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['columnB'], '2')
+        self.assertEquals(rows[0]['columnB'], '2')
 
 class TestOptions(unittest.TestCase):
 
@@ -28,14 +28,14 @@ class TestOptions(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['columnA']})
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['columnA'], '1')
+        self.assertEquals(rows[0]['columnA'], '1')
 
         with self.assertRaises(Exception):
             row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['fizz']})
 
         row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']})
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['columnA'], '1')
+        self.assertEquals(rows[0]['columnA'], '1')
 
         with self.assertRaises(Exception):
             row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['fizz']})
@@ -47,7 +47,7 @@ class TestRestKeyWithDuplicateHeader(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
+        self.assertEquals(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
 
 class TestRestValue(unittest.TestCase):
 
@@ -56,7 +56,7 @@ class TestRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB"])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB"])
 
 class TestDuplicateHeaders(unittest.TestCase):
 
@@ -65,8 +65,8 @@ class TestDuplicateHeaders(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEquals(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestKey(unittest.TestCase):
 
@@ -75,8 +75,8 @@ class TestDuplicateHeadersRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEquals(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValue(unittest.TestCase):
 
@@ -85,8 +85,8 @@ class TestDuplicateHeadersRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEquals(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
 
@@ -95,17 +95,17 @@ class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
 class TestMissingFiedInCatalog(unittest.TestCase):
 
     csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5,6"]
 
-    def test(self, mocked_logger_warning):
+    def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, ["columnA","columnB"], True)
         rows = [r for r in row_iterator]
         self.assertListEqual(rows[0]['_sdc_extra'], [{"columnC": ["3", "5", "6"]},{"columnB": "4"}])
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
 
 
 class TestWarningForDupHeaders(unittest.TestCase):
@@ -116,6 +116,6 @@ class TestWarningForDupHeaders(unittest.TestCase):
     def test(self, mocked_logger_warn):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
-from singer_encodings import csv
 from singer_encodings.csv_helper import CSVHelper
+from singer_encodings import csv
 
 class TestRestKey(unittest.TestCase):
 
@@ -47,7 +47,7 @@ class TestRestKeyWithDuplicateHeader(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], ["{\"no_headers\": [\"4\"]}"])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
 
 class TestRestValue(unittest.TestCase):
 
@@ -65,7 +65,7 @@ class TestDuplicateHeaders(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], ["{\"columnB\": \"4\"}","{\"columnC\": [\"5\", \"6\"]}"])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestKey(unittest.TestCase):
@@ -75,7 +75,7 @@ class TestDuplicateHeadersRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'],  ["{\"no_headers\": [\"7\", \"8\", \"9\"]}","{\"columnB\": \"4\"}","{\"columnC\": [\"5\", \"6\"]}"])
+        self.assertEqual(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValue(unittest.TestCase):
@@ -85,7 +85,7 @@ class TestDuplicateHeadersRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['_sdc_extra'], ["{\"columnB\": \"4\"}","{\"columnC\": \"5\"}"])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
@@ -101,15 +101,15 @@ class TestMissingFiedInCatalog(unittest.TestCase):
 
     csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5,6"]
 
-    def test(self):
+    def test(self, mocked_logger_warning):
         row_iterator = csv.get_row_iterator(self.csv_data, None, ["columnA","columnB"], True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'], ["{\"columnC\": [\"3\", \"5\", \"6\"]}","{\"columnB\": \"4\"}",])
+        self.assertListEqual(rows[0]['_sdc_extra'], [{"columnC": ["3", "5", "6"]},{"columnB": "4"}])
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
 
 
 class TestWarningForDupHeaders(unittest.TestCase):
-    
+
     csv_data = [b"columnA,columnB,columnC,columnC", b"1,2,3"]
 
     @mock.patch("singer_encodings.csv_helper.LOGGER.warn")

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,5 +1,7 @@
 import unittest
+from unittest import mock
 from singer_encodings import csv
+from singer_encodings.csv_helper import CSVHelper
 
 class TestRestKey(unittest.TestCase):
 
@@ -17,7 +19,7 @@ class TestNullBytes(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertEqual(rows[0]['columnA'], '1')
+        self.assertEqual(rows[0]['columnB'], '2')
 
 class TestOptions(unittest.TestCase):
 
@@ -37,3 +39,83 @@ class TestOptions(unittest.TestCase):
 
         with self.assertRaises(Exception):
             row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['fizz']})
+
+class TestRestKeyWithDuplicateHeader(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC", b"1,2,3,4"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['_sdc_extra'], ["{\"no_headers\": [\"4\"]}"])
+
+class TestRestValue(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC", b"1,2"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB"])
+
+class TestDuplicateHeaders(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5,6"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['_sdc_extra'], ["{\"columnB\": \"4\"}","{\"columnC\": [\"5\", \"6\"]}"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+
+class TestDuplicateHeadersRestKey(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5,6,7,8,9"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['_sdc_extra'],  ["{\"no_headers\": [\"7\", \"8\", \"9\"]}","{\"columnB\": \"4\"}","{\"columnC\": [\"5\", \"6\"]}"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+
+class TestDuplicateHeadersRestValue(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['_sdc_extra'], ["{\"columnB\": \"4\"}","{\"columnC\": \"5\"}"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+
+class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+
+class TestMissingFiedInCatalog(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC,columnB,columnC,columnC", b"1,2,3,4,5,6"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, ["columnA","columnB"], True)
+        rows = [r for r in row_iterator]
+        self.assertListEqual(rows[0]['_sdc_extra'], ["{\"columnC\": [\"3\", \"5\", \"6\"]}","{\"columnB\": \"4\"}",])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
+
+
+class TestWarningForDupHeaders(unittest.TestCase):
+    
+    csv_data = [b"columnA,columnB,columnC,columnC", b"1,2,3"]
+
+    @mock.patch("singer_encodings.csv_helper.LOGGER.warn")
+    def test(self, mocked_logger_warn):
+        row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+
+        mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -10,7 +10,7 @@ class TestRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'], ['4'])
+        self.assertEqual(rows[0]['_sdc_extra'], ['4'])
 
 class TestNullBytes(unittest.TestCase):
 
@@ -47,7 +47,7 @@ class TestRestKeyWithDuplicateHeader(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
 
 class TestRestValue(unittest.TestCase):
 
@@ -56,7 +56,10 @@ class TestRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB"])
+        print(">>>>>>>>>>>>")
+        print(rows)
+        print(rows[0].keys())
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB"])
 
 class TestDuplicateHeaders(unittest.TestCase):
 
@@ -65,8 +68,8 @@ class TestDuplicateHeaders(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestKey(unittest.TestCase):
 
@@ -75,8 +78,8 @@ class TestDuplicateHeadersRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEqual(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValue(unittest.TestCase):
 
@@ -85,8 +88,8 @@ class TestDuplicateHeadersRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
 
@@ -95,7 +98,7 @@ class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
 class TestMissingFiedInCatalog(unittest.TestCase):
 
@@ -105,7 +108,7 @@ class TestMissingFiedInCatalog(unittest.TestCase):
         row_iterator = csv.get_row_iterator(self.csv_data, None, ["columnA","columnB"], True)
         rows = [r for r in row_iterator]
         self.assertListEqual(rows[0]['_sdc_extra'], [{"columnC": ["3", "5", "6"]},{"columnB": "4"}])
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
 
 
 class TestWarningForDupHeaders(unittest.TestCase):
@@ -116,6 +119,6 @@ class TestWarningForDupHeaders(unittest.TestCase):
     def test(self, mocked_logger_warn):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -21,6 +21,33 @@ class TestNullBytes(unittest.TestCase):
         rows = [r for r in row_iterator]
         self.assertEqual(rows[0]['columnB'], '2')
 
+
+class TestOptionsWithDuplicateHeaders(unittest.TestCase):
+
+    csv_data = [b"columnA,columnB,columnC", b"1,2,3"]
+
+    def test(self):
+        row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['columnA']})
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['columnA'], '1')
+
+        try:
+            row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['fizz']})
+        except Exception as ex:
+            expected_message = "CSV file missing required headers: {'fizz'}"
+            self.assertEquals(expected_message, str(ex))
+
+        row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']}, headers_in_catalog=None, with_duplicate_headers=True)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0]['columnA'], '1')
+
+        try:
+            row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']}, headers_in_catalog=None, with_duplicate_headers=True)
+        except Exception as ex:
+            expected_message = "CSV file missing date_overrides headers: {'fizz'}"
+            self.assertEquals(expected_message, str(ex))
+
+
 class TestOptions(unittest.TestCase):
 
     csv_data = [b"columnA,columnB,columnC", b"1,2,3"]
@@ -41,7 +68,7 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(rows[0]['columnA'], '1')
 
         try:
-            row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['fizz']})
+            row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']})
         except Exception as ex:
             expected_message = "CSV file missing date_overrides headers: {'fizz'}"
             self.assertEquals(expected_message, str(ex))

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -116,9 +116,6 @@ class TestWarningForDupHeaders(unittest.TestCase):
     def test(self, mocked_logger_warn):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        print(">>>>>>>>>>>>")
-        print(rows)
-        print(rows[0].keys())
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -10,7 +10,7 @@ class TestRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['_sdc_extra'], ['4'])
+        self.assertListEqual(rows[0]['_sdc_extra'], ['4'])
 
 class TestNullBytes(unittest.TestCase):
 
@@ -19,7 +19,7 @@ class TestNullBytes(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['columnB'], '2')
+        self.assertEqual(rows[0]['columnB'], '2')
 
 class TestOptions(unittest.TestCase):
 
@@ -28,14 +28,14 @@ class TestOptions(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['columnA']})
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['columnA'], '1')
+        self.assertEqual(rows[0]['columnA'], '1')
 
         with self.assertRaises(Exception):
             row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['fizz']})
 
         row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']})
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['columnA'], '1')
+        self.assertEqual(rows[0]['columnA'], '1')
 
         with self.assertRaises(Exception):
             row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['fizz']})
@@ -47,7 +47,7 @@ class TestRestKeyWithDuplicateHeader(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
+        self.assertListEqual(rows[0]['_sdc_extra'], [{"no_headers": ["4"]}])
 
 class TestRestValue(unittest.TestCase):
 
@@ -56,7 +56,7 @@ class TestRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB"])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB"])
 
 class TestDuplicateHeaders(unittest.TestCase):
 
@@ -65,8 +65,8 @@ class TestDuplicateHeaders(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertListEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestKey(unittest.TestCase):
 
@@ -75,8 +75,8 @@ class TestDuplicateHeadersRestKey(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertListEqual(rows[0]['_sdc_extra'],  [{"no_headers": ["7", "8", "9"]},{"columnB": "4"},{"columnC": ["5", "6"]}])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValue(unittest.TestCase):
 
@@ -85,8 +85,8 @@ class TestDuplicateHeadersRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
+        self.assertListEqual(rows[0]['_sdc_extra'], [{"columnB": "4"},{"columnC": "5"}])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC","_sdc_extra"])
 
 class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
 
@@ -95,7 +95,7 @@ class TestDuplicateHeadersRestValueNoSDCExtra(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
 class TestMissingFiedInCatalog(unittest.TestCase):
 
@@ -105,7 +105,7 @@ class TestMissingFiedInCatalog(unittest.TestCase):
         row_iterator = csv.get_row_iterator(self.csv_data, None, ["columnA","columnB"], True)
         rows = [r for r in row_iterator]
         self.assertListEqual(rows[0]['_sdc_extra'], [{"columnC": ["3", "5", "6"]},{"columnB": "4"}])
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","_sdc_extra"])
 
 
 class TestWarningForDupHeaders(unittest.TestCase):
@@ -116,6 +116,6 @@ class TestWarningForDupHeaders(unittest.TestCase):
     def test(self, mocked_logger_warn):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        self.assertEquals(list(rows[0].keys()), ["columnA","columnB","columnC"])
+        self.assertListEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -56,9 +56,6 @@ class TestRestValue(unittest.TestCase):
     def test(self):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
-        print(">>>>>>>>>>>>")
-        print(rows)
-        print(rows[0].keys())
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB"])
 
 class TestDuplicateHeaders(unittest.TestCase):
@@ -119,6 +116,9 @@ class TestWarningForDupHeaders(unittest.TestCase):
     def test(self, mocked_logger_warn):
         row_iterator = csv.get_row_iterator(self.csv_data, None, None, True)
         rows = [r for r in row_iterator]
+        print(">>>>>>>>>>>>")
+        print(rows)
+        print(rows[0].keys())
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -30,15 +30,21 @@ class TestOptions(unittest.TestCase):
         rows = [r for r in row_iterator]
         self.assertEqual(rows[0]['columnA'], '1')
 
-        with self.assertRaises(Exception):
+        try:
             row_iterator = csv.get_row_iterator(self.csv_data, options={'key_properties': ['fizz']})
+        except Exception as ex:
+            expected_message = "CSV file missing required headers: {'fizz'}"
+            self.assertEquals(expected_message, str(ex))
 
         row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['columnA']})
         rows = [r for r in row_iterator]
         self.assertEqual(rows[0]['columnA'], '1')
 
-        with self.assertRaises(Exception):
+        try:
             row_iterator = csv.get_row_iterator(self.csv_data, options={'date_overrides': ['fizz']})
+        except Exception as ex:
+            expected_message = "CSV file missing date_overrides headers: {'fizz'}"
+            self.assertEquals(expected_message, str(ex))
 
 class TestRestKeyWithDuplicateHeader(unittest.TestCase):
 


### PR DESCRIPTION
# Description of change
Added support to handle duplicate headers in the CSV file. Earlier, the library was returning wrong data when the CSV file is having duplicate headers. As part of the upcoming version of tap-s3-CSV, we got a customer case to handle such a scenario and hence the code has been added keeping in mind the backward compatibility of the module for other taps.

Duplicate headers will be added in a key called '_sdc_extra' in the response of the library

# Manual QA steps
 - Monitored the tap-s3-CSV workflow with the latest code of the singer-encoding module. (Discovery mode and sync mode)
 
# Risks
 - No Risks
 
# Rollback steps
 - revert this branch
