### PR TITLE
fix: Updated code to handle StopIteration exception for empty csv

### DIFF
--- a/singer_encodings/csv_helper.py
+++ b/singer_encodings/csv_helper.py
@@ -117,7 +117,11 @@ class CSVHelper:
 
         # Replace any NULL bytes in the line given to the Reader
         reader = csv.reader((line.replace('\0', '') for line in file_stream), delimiter=delimiter)
-        self.all_csv_headers = next(reader)
+        try:
+            self.all_csv_headers = next(reader)
+        except StopIteration:
+            # Return None if CSV file is empty.
+            return None
         header_index = 0
 
         for header in self.all_csv_headers:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -152,3 +152,11 @@ class TestWarningForDupHeaders(unittest.TestCase):
         self.assertEqual(list(rows[0].keys()), ["columnA","columnB","columnC"])
 
         mocked_logger_warn.assert_called_with('Duplicate Header(s) %s found in the csv and its value will be stored in the \"_sdc_extra\" field.', {'columnC'})
+
+
+class TestReturnNoneForEmptyCSV(unittest.TestCase):
+
+    @mock.patch("singer_encodings.csv_helper.LOGGER.warn")
+    def test_get_row_iterator_return_none_for_empty_csv(self, mocked_logger_warn):
+        row_iterator = csv.get_row_iterator([], None, None, True)
+        self.assertEqual(row_iterator,None)


### PR DESCRIPTION
# Description of change
- Handled StopIteration exception for empty CSV file.

# Manual QA steps
 - Run s3-csv for empty CSV file and getting None instead of StopIteration error.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
