### PR TITLE
TDL15970-utf8-fix

### DIFF
--- a/singer_encodings/csv.py
+++ b/singer_encodings/csv.py
@@ -23,7 +23,7 @@ def get_row_iterator(iterable, options=None, headers_in_catalog = None, with_dup
     options = options or {}
     reader = []
     headers = set()
-    file_stream = codecs.iterdecode(iterable, encoding='utf-8')
+    file_stream = codecs.iterdecode(iterable, encoding='utf-8-sig')
     delimiter = options.get('delimiter', ',')
 
     # Return the CSV key-values along with considering the duplicate headers, if any, in the CSV file


### PR DESCRIPTION
# Description of change
tap-s3-csv issue was reported by customer that primary key column in not idenfied as mentioned in csv. Found that this issue with UnicodeEncodeError ufeff being or getting appended. Changed utf-8 to utf-8-sig solved the problem. 

# Manual QA steps
 - Validated locally by changing to utf-8-sig in the library and ran the test and there are no exceptions related to primary key
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
