### PR TITLE
Added variable for `_sdc_extra` field.

### DIFF
--- a/singer_encodings/json_schema.py
+++ b/singer_encodings/json_schema.py
@@ -4,6 +4,7 @@ from . import csv
 
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"
 SDC_SOURCE_LINENO_COLUMN = "_sdc_source_lineno"
+SDC_EXTRA_VALUE = {"type": "array", "items": {"type": "string"}}
 
 # TODO: Add additional logging
 
@@ -26,7 +27,7 @@ def get_schema_for_table(conn, table_spec):
         **schema,
         SDC_SOURCE_FILE_COLUMN: {'type': 'string'},
         SDC_SOURCE_LINENO_COLUMN: {'type': 'integer'},
-        csv.SDC_EXTRA_COLUMN: {'type': 'array', 'items': {'type': 'string'}},
+        csv.SDC_EXTRA_COLUMN: SDC_EXTRA_VALUE,
     }
 
     return {


### PR DESCRIPTION
# Description of change
Added variable for `_sdc_extra` field.
- Updated the code to store **_sdc_extra** field value in a variable to extend in Tap-SFTP JSONL support PR [#40](https://github.com/singer-io/tap-sftp/pull/40).

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
