### PR TITLE
SAC-28672: add jsonl support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-encodings",
-      version='0.2.0',
+      version='0.3.0',
       description="Singer.io encodings library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer_encodings/jsonl.py
+++ b/singer_encodings/jsonl.py
@@ -1,0 +1,10 @@
+import json
+
+def get_row_iterator(file_like_handle):
+    for row in file_like_handle:
+        if isinstance(row, bytes):
+            row = row.decode('utf-8')
+        if row.strip():
+            parsed_row = json.loads(row)
+            if len(parsed_row):
+                yield parsed_row

--- a/tests/test_jsonl.py
+++ b/tests/test_jsonl.py
@@ -1,0 +1,48 @@
+import json
+import unittest
+import tempfile
+from unittest import mock
+from singer_encodings.jsonl import get_row_iterator
+
+
+class TestGetRowIterator(unittest.TestCase):
+    def setUp(self):
+        self.jsonl_file = tempfile.TemporaryFile('w+')
+        data = [{
+            "id": i,
+            "name": f"user_{i}",
+            "value": i * 1.5
+        }
+        for i in range(1, 101)]
+        for row in data:
+            json.dump(row, self.jsonl_file)
+            self.jsonl_file.write('\n')
+        self.jsonl_file.seek(0)
+
+    def tearDown(self):
+        self.jsonl_file.close()
+
+    def test(self):
+        row_iterator = get_row_iterator(self.jsonl_file)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows[0], {'id': 1, 'name': 'user_1', 'value': 1.5})
+        self.assertEqual(rows[99], {'id': 100, 'name': 'user_100', 'value': 150})
+        self.assertEqual(len(rows), 100)
+
+class TestGetRowIteratorSkipsEmptyRows(unittest.TestCase):
+    def setUp(self):
+        self.jsonl_file = tempfile.TemporaryFile('w+')
+        self.jsonl_file.write('\n\n\n')
+        json.dump({'a': 1}, self.jsonl_file)
+        self.jsonl_file.write('\n    \n\n     \n\t\n')
+        json.dump({}, self.jsonl_file)
+        self.jsonl_file.write('\n')
+        self.jsonl_file.seek(0)
+
+    def tearDown(self):
+        self.jsonl_file.close()
+
+    def test(self):
+        row_iterator = get_row_iterator(self.jsonl_file)
+        rows = [r for r in row_iterator]
+        self.assertEqual(rows, [{'a': 1}])


### PR DESCRIPTION
# Description of change
Add jsonl support to singer-encodings
https://qlik-dev.atlassian.net/browse/SAC-28672

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
