### PR TITLE
SAC-31618: add memory-efficient Parquet sampling functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+* Add `sample_row_iterator()` to `parquet` module for memory-efficient discovery-time schema sampling [SAC-31618](https://qlik-dev.atlassian.net/browse/SAC-31618)
+
+### Added
+- `sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000)` in `singer_encodings.parquet` - filters rows at the Arrow level (via `Table.take()`) *before* converting them to Python objects, unlike `get_row_iterator()` combined with post-hoc filtering, which always converted an entire row group to Python objects regardless of `sample_rate`. Skips decompressing row groups with no sampled rows, and stops reading further row groups once `max_records` is reached.
+- `get_row_iterator()` is unchanged and should still be used for full syncs, which need every row.
+
 ## [0.5.0]
 * Bump `pyarrow` dependency to improve compatibility and performance [#31](https://github.com/singer-io/singer-encodings/pull/31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.6.0]
-* Add `sample_row_iterator()` and `is_empty()` to `parquet` module for memory-efficient discovery-time schema sampling (SAC-31618)
+* Add `sample_row_iterator()` and `is_empty()` to `parquet` module for memory-efficient discovery-time schema sampling [#32](https://github.com/singer-io/singer-encodings/pull/32)
 
 ### Added
 - `sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000)` in `singer_encodings.parquet` - filters rows at the Arrow level (via `Table.take()`) *before* converting them to Python objects, unlike `get_row_iterator()` combined with post-hoc filtering, which always converted an entire row group to Python objects regardless of `sample_rate`. Skips decompressing row groups with no sampled rows, and stops reading further row groups once `max_records` is reached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.6.0]
-* Add `sample_row_iterator()` to `parquet` module for memory-efficient discovery-time schema sampling [SAC-31618](https://qlik-dev.atlassian.net/browse/SAC-31618)
+* Add `sample_row_iterator()` and `is_empty()` to `parquet` module for memory-efficient discovery-time schema sampling (SAC-31618)
 
 ### Added
 - `sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000)` in `singer_encodings.parquet` - filters rows at the Arrow level (via `Table.take()`) *before* converting them to Python objects, unlike `get_row_iterator()` combined with post-hoc filtering, which always converted an entire row group to Python objects regardless of `sample_rate`. Skips decompressing row groups with no sampled rows, and stops reading further row groups once `max_records` is reached.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000)` in `singer_encodings.parquet` - filters rows at the Arrow level (via `Table.take()`) *before* converting them to Python objects, unlike `get_row_iterator()` combined with post-hoc filtering, which always converted an entire row group to Python objects regardless of `sample_rate`. Skips decompressing row groups with no sampled rows, and stops reading further row groups once `max_records` is reached.
+- `is_empty(file_like_handle)` in `singer_encodings.parquet` - returns `True` if the Parquet file has no rows, reading only the footer metadata (no row group decompression).
 - `get_row_iterator()` is unchanged and should still be used for full syncs, which need every row.
 
 ## [0.5.0]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ with open('data.parquet', 'rb') as parquet_file:
         print(row)
 ```
 
+`get_row_iterator()` reads a Parquet file row-group by row-group, converting each row group's decompressed data into Python objects as it goes. It yields **every** row and should be used when you need the full dataset, such as during a full sync.
+
+#### Sampling for Schema Discovery
+
+If you only need a subset of rows - for example, to infer a schema during discovery - use `sample_row_iterator()` instead of wrapping `get_row_iterator()` with your own filtering. Filtering after the fact still requires each row group to be fully converted to Python objects before any rows are discarded, which can spike memory well beyond what's actually needed for a sample. `sample_row_iterator()` filters at the Arrow level, before conversion, so only the rows you actually keep are ever materialized as Python objects, and it skips decompressing row groups entirely when none of their rows would be sampled:
+
+```python
+from singer_encodings.parquet import sample_row_iterator
+
+with open('data.parquet', 'rb') as parquet_file:
+    # Yields every 5th row (globally, across all row groups), up to 1000 rows.
+    for row in sample_row_iterator(parquet_file, sample_rate=5, max_records=1000):
+        print(row)
+```
+
+- `sample_rate`: yield every Nth row, using a row index counted globally across all row groups.
+- `max_records`: stop once this many rows have been yielded. Pass `None` for no limit (iteration still ends at EOF).
+
+Do not use `sample_row_iterator()` for full syncs - it is only intended for cases where sampling a subset of rows is the goal.
+
 ## Development
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ with open('data.parquet', 'rb') as parquet_file:
 
 Do not use `sample_row_iterator()` for full syncs - it is only intended for cases where sampling a subset of rows is the goal.
 
+#### Checking for Empty Files
+
+`is_empty()` checks whether a Parquet file has any rows by reading only its footer metadata - it never decompresses row group data, so it's cheap to call before deciding whether to read a file at all:
+
+```python
+from singer_encodings.parquet import is_empty
+
+with open('data.parquet', 'rb') as parquet_file:
+    if is_empty(parquet_file):
+        print("File has no rows")
+```
+
 ## Development
 
 ### Running Tests

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="singer-encodings",
-      version='0.5.0',
+      version='0.6.0',
       description="Singer.io encodings library",
       author="Stitch",
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/singer_encodings/parquet.py
+++ b/singer_encodings/parquet.py
@@ -8,6 +8,17 @@ def get_row_iterator(file_like_handle):
         yield from rows.to_pylist()
 
 
+def is_empty(file_like_handle):
+    """Returns True if the Parquet file has no rows.
+
+    Only reads the file's footer metadata - never decompresses any row
+    group data - so it's cheap to call before deciding whether to read
+    the file at all.
+    """
+    pf = pq.ParquetFile(file_like_handle)
+    return pf.metadata.num_rows == 0
+
+
 def sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000):
     """Row-group-aware sampling iterator, intended ONLY for discovery-time
     schema sampling - do NOT use this for full syncs.

--- a/singer_encodings/parquet.py
+++ b/singer_encodings/parquet.py
@@ -6,3 +6,60 @@ def get_row_iterator(file_like_handle):
     for i in range(pf.num_row_groups):
         rows = pf.read_row_group(i)
         yield from rows.to_pylist()
+
+
+def sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000):
+    """Row-group-aware sampling iterator, intended ONLY for discovery-time
+    schema sampling - do NOT use this for full syncs.
+
+    get_row_iterator() must yield every row, since taps also use it during
+    full syncs. That means taps doing discovery-time sampling have had to
+    wrap get_row_iterator() and filter rows *after* rows.to_pylist() already
+    converted an entire row group's decompressed data into Python objects,
+    so sampling provided no memory benefit at all - a file with few/large
+    row groups could still cause the same memory spike a full sync would,
+    even though discovery only needs a small sample of its rows.
+
+    This function filters at the Arrow level (via Table.take()) *before*
+    converting anything to Python objects, so only the rows that will
+    actually be sampled are ever materialized as Python objects. It also
+    skips decompressing a row group entirely if none of its rows fall on
+    the sample_rate boundary, and stops reading further row groups as soon
+    as max_records sampled rows have been yielded.
+
+    Args:
+        file_like_handle: a file-like object pointing at a Parquet file.
+        sample_rate: yield every Nth row, using a row index counted
+            globally across all row groups (matching the semantics taps
+            previously implemented themselves via `row_idx % sample_rate`).
+        max_records: stop once this many rows have been yielded. Pass
+            None for no limit (iteration still ends at EOF).
+    """
+    pf = pq.ParquetFile(file_like_handle)
+    current_row = 0
+    yielded = 0
+
+    for i in range(pf.num_row_groups):
+        num_rows = pf.metadata.row_group(i).num_rows
+
+        # Figure out which rows in this row group we want *before*
+        # decompressing anything.
+        indices = [
+            row_offset for row_offset in range(num_rows)
+            if (current_row + row_offset) % sample_rate == 0
+        ]
+        current_row += num_rows
+
+        if not indices:
+            # None of this row group's rows are sampled - skip
+            # decompressing it entirely.
+            continue
+
+        table = pf.read_row_group(i)
+        sampled_table = table.take(indices)
+
+        for row in sampled_table.to_pylist():
+            yield row
+            yielded += 1
+            if max_records is not None and yielded >= max_records:
+                return

--- a/singer_encodings/parquet.py
+++ b/singer_encodings/parquet.py
@@ -61,9 +61,17 @@ def sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000):
         ]
         current_row += num_rows
 
+        if max_records is not None:
+            # Cap to the remaining budget *before* take()/to_pylist(), so a
+            # single large row group whose sampled rows exceed max_records
+            # never materializes more Python objects than we'll actually
+            # yield. Without this, to_pylist() converts every sampled row
+            # in the row group up front, regardless of max_records.
+            indices = indices[:max_records - yielded]
+
         if not indices:
-            # None of this row group's rows are sampled - skip
-            # decompressing it entirely.
+            # None of this row group's rows are sampled (or the budget is
+            # already exhausted) - skip decompressing it entirely.
             continue
 
         table = pf.read_row_group(i)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -6,7 +6,7 @@ from unittest import mock
 from singer_encodings.parquet import get_row_iterator, sample_row_iterator, is_empty
 
 
-def make_parquet_file(num_rows=100, row_group_size=None):
+def make_parquet_file(num_rows=100, row_group_size=None, compression='snappy'):
     parquet_file = tempfile.TemporaryFile('w+b')
     data = {
         "id": list(range(1, num_rows + 1)),
@@ -14,7 +14,7 @@ def make_parquet_file(num_rows=100, row_group_size=None):
         "value": [i * 1.5 for i in range(1, num_rows + 1)],
     }
     table = pa.table(data)
-    pq.write_table(table, parquet_file, row_group_size=row_group_size)
+    pq.write_table(table, parquet_file, row_group_size=row_group_size, compression=compression)
     parquet_file.seek(0)
     return parquet_file
 
@@ -120,6 +120,41 @@ class TestSampleRowIterator(unittest.TestCase):
         rows = list(sample_row_iterator(self.parquet_file, sample_rate=5, max_records=1000))
 
         self.assertEqual(rows, [])
+
+
+class TestSnappyCompression(unittest.TestCase):
+    # Snappy is pyarrow's default Parquet compression codec, so every
+    # other test in this file already exercises it implicitly via
+    # make_parquet_file(). This test makes that coverage explicit: it
+    # writes a file with compression='snappy', confirms the codec is
+    # actually SNAPPY at the row-group level, and verifies both
+    # get_row_iterator() (full sync) and sample_row_iterator()
+    # (schema discovery) decode it correctly.
+    def tearDown(self):
+        self.parquet_file.close()
+
+    def test_row_group_reports_snappy_codec(self):
+        self.parquet_file = make_parquet_file(num_rows=10, compression='snappy')
+
+        pf = pq.ParquetFile(self.parquet_file)
+        compression = pf.metadata.row_group(0).column(0).compression
+
+        self.assertEqual(compression, 'SNAPPY')
+
+    def test_get_row_iterator_reads_snappy_compressed_file(self):
+        self.parquet_file = make_parquet_file(num_rows=10, compression='snappy')
+
+        rows = list(get_row_iterator(self.parquet_file))
+
+        self.assertEqual(len(rows), 10)
+        self.assertEqual(rows[0], {'id': 1, 'name': 'user_1', 'value': 1.5})
+
+    def test_sample_row_iterator_reads_snappy_compressed_file(self):
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10, compression='snappy')
+
+        rows = list(sample_row_iterator(self.parquet_file, sample_rate=25, max_records=1000))
+
+        self.assertEqual([r['id'] for r in rows], [1, 26, 51, 76])
 
 
 class TestIsEmpty(unittest.TestCase):

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -119,8 +119,8 @@ class TestSampleRowIterator(unittest.TestCase):
         # more rows than max_records. Without capping `indices` to the
         # remaining budget before take()/to_pylist(), the whole
         # sample_rate-filtered subset of the row group gets converted to
-        # Python objects up front, regardless of max_records - the exact
-        # single-large-row-group scenario this ticket is about.
+        # Python objects up front, regardless of max_records - a real risk
+        # for files written as a single large row group.
         self.parquet_file = make_parquet_file(num_rows=1000, row_group_size=1000)
         original_read_row_group = pq.ParquetFile.read_row_group
         take_call_sizes = []

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import tempfile
 from unittest import mock
-from singer_encodings.parquet import get_row_iterator, sample_row_iterator
+from singer_encodings.parquet import get_row_iterator, sample_row_iterator, is_empty
 
 
 def make_parquet_file(num_rows=100, row_group_size=None):
@@ -120,3 +120,28 @@ class TestSampleRowIterator(unittest.TestCase):
         rows = list(sample_row_iterator(self.parquet_file, sample_rate=5, max_records=1000))
 
         self.assertEqual(rows, [])
+
+
+class TestIsEmpty(unittest.TestCase):
+    def tearDown(self):
+        self.parquet_file.close()
+
+    def test_true_for_a_file_with_zero_rows(self):
+        self.parquet_file = make_parquet_file(num_rows=0)
+
+        self.assertTrue(is_empty(self.parquet_file))
+
+    def test_false_for_a_file_with_rows(self):
+        self.parquet_file = make_parquet_file(num_rows=1)
+
+        self.assertFalse(is_empty(self.parquet_file))
+
+    def test_does_not_decompress_any_row_group(self):
+        # is_empty() should only need the footer metadata - never call
+        # read_row_group.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        with mock.patch.object(pq.ParquetFile, 'read_row_group') as mocked_read:
+            is_empty(self.parquet_file)
+
+        mocked_read.assert_not_called()

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -3,19 +3,25 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import tempfile
 from unittest import mock
-from singer_encodings.parquet import get_row_iterator
+from singer_encodings.parquet import get_row_iterator, sample_row_iterator
+
+
+def make_parquet_file(num_rows=100, row_group_size=None):
+    parquet_file = tempfile.TemporaryFile('w+b')
+    data = {
+        "id": list(range(1, num_rows + 1)),
+        "name": [f"user_{i}" for i in range(1, num_rows + 1)],
+        "value": [i * 1.5 for i in range(1, num_rows + 1)],
+    }
+    table = pa.table(data)
+    pq.write_table(table, parquet_file, row_group_size=row_group_size)
+    parquet_file.seek(0)
+    return parquet_file
 
 
 class TestGetRowIterator(unittest.TestCase):
     def setUp(self):
-        self.parquet_file = tempfile.TemporaryFile('w+b')
-        data = {
-            "id": list(range(1, 101)),  # integers 1–100
-            "name": [f"user_{i}" for i in range(1, 101)],  # strings
-            "value": [i * 1.5 for i in range(1, 101)],  # floats
-        }
-        table = pa.table(data)
-        pq.write_table(table, self.parquet_file)
+        self.parquet_file = make_parquet_file(num_rows=100)
 
     def tearDown(self):
         self.parquet_file.close()
@@ -26,3 +32,91 @@ class TestGetRowIterator(unittest.TestCase):
         self.assertEqual(rows[0], {'id': 1, 'name': 'user_1', 'value': 1.5})
         self.assertEqual(rows[99], {'id': 100, 'name': 'user_100', 'value': 150})
         self.assertEqual(len(rows), 100)
+
+
+class TestSampleRowIterator(unittest.TestCase):
+    def tearDown(self):
+        self.parquet_file.close()
+
+    def test_matches_post_hoc_sampling_of_get_row_iterator(self):
+        # sample_row_iterator should yield exactly the rows that the old
+        # "wrap get_row_iterator() and filter after the fact" approach
+        # would have produced, for the same sample_rate/max_records.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        sample_rate = 7
+        max_records = 1000
+
+        expected = []
+        for idx, row in enumerate(get_row_iterator(self.parquet_file)):
+            if idx % sample_rate == 0:
+                expected.append(row)
+                if len(expected) >= max_records:
+                    break
+
+        self.parquet_file.seek(0)
+        actual = list(sample_row_iterator(self.parquet_file, sample_rate, max_records))
+
+        self.assertEqual(actual, expected)
+
+    def test_respects_max_records_across_row_groups(self):
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        rows = list(sample_row_iterator(self.parquet_file, sample_rate=1, max_records=25))
+
+        self.assertEqual(len(rows), 25)
+        self.assertEqual(rows[0], {'id': 1, 'name': 'user_1', 'value': 1.5})
+        self.assertEqual(rows[-1], {'id': 25, 'name': 'user_25', 'value': 37.5})
+
+    def test_default_sample_rate_and_max_records(self):
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        rows = list(sample_row_iterator(self.parquet_file))
+
+        # default sample_rate=5 -> ids 1, 6, 11, ... ; default max_records=1000
+        # is well above the 20 rows sample_rate=5 would produce from 100 rows.
+        self.assertEqual(len(rows), 20)
+        self.assertEqual([r['id'] for r in rows], list(range(1, 101, 5)))
+
+    def test_max_records_none_means_unlimited(self):
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+
+        rows = list(sample_row_iterator(self.parquet_file, sample_rate=10, max_records=None))
+
+        self.assertEqual(len(rows), 10)
+        self.assertEqual([r['id'] for r in rows], list(range(1, 101, 10)))
+
+    def test_stops_reading_row_groups_once_max_records_reached(self):
+        # 10 row groups of 10 rows each; sample_rate=1 means every row in
+        # row group 0 (rows 0-9) already satisfies max_records=5, so
+        # read_row_group should only ever be called once.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+        original_read_row_group = pq.ParquetFile.read_row_group
+
+        with mock.patch.object(pq.ParquetFile, 'read_row_group', autospec=True) as mocked_read:
+            mocked_read.side_effect = original_read_row_group
+            rows = list(sample_row_iterator(self.parquet_file, sample_rate=1, max_records=5))
+
+        self.assertEqual(len(rows), 5)
+        self.assertEqual(mocked_read.call_count, 1)
+
+    def test_skips_decompressing_row_groups_with_no_sampled_rows(self):
+        # 10 row groups of 10 rows each; sample_rate=25 only lands on rows
+        # 0, 25, 50, 75 - i.e. row groups 0, 2, 5, 7. The other 6 row
+        # groups should never be decompressed via read_row_group at all.
+        self.parquet_file = make_parquet_file(num_rows=100, row_group_size=10)
+        original_read_row_group = pq.ParquetFile.read_row_group
+
+        with mock.patch.object(pq.ParquetFile, 'read_row_group', autospec=True) as mocked_read:
+            mocked_read.side_effect = original_read_row_group
+            rows = list(sample_row_iterator(self.parquet_file, sample_rate=25, max_records=1000))
+
+        self.assertEqual([r['id'] for r in rows], [1, 26, 51, 76])
+        self.assertEqual(mocked_read.call_count, 4)
+
+    def test_empty_file(self):
+        self.parquet_file = make_parquet_file(num_rows=0)
+
+        rows = list(sample_row_iterator(self.parquet_file, sample_rate=5, max_records=1000))
+
+        self.assertEqual(rows, [])

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -114,6 +114,41 @@ class TestSampleRowIterator(unittest.TestCase):
         self.assertEqual([r['id'] for r in rows], [1, 26, 51, 76])
         self.assertEqual(mocked_read.call_count, 4)
 
+    def test_caps_materialized_rows_to_max_records_within_a_single_large_row_group(self):
+        # A single row group large enough that sample_rate alone selects far
+        # more rows than max_records. Without capping `indices` to the
+        # remaining budget before take()/to_pylist(), the whole
+        # sample_rate-filtered subset of the row group gets converted to
+        # Python objects up front, regardless of max_records - the exact
+        # single-large-row-group scenario this ticket is about.
+        self.parquet_file = make_parquet_file(num_rows=1000, row_group_size=1000)
+        original_read_row_group = pq.ParquetFile.read_row_group
+        take_call_sizes = []
+
+        class TakeSpy:
+            # Wraps the real pa.Table so we can observe how many indices
+            # take() is called with, without needing to patch pyarrow's
+            # immutable Table type directly.
+            def __init__(self, table):
+                self._table = table
+
+            def take(self, indices):
+                take_call_sizes.append(len(indices))
+                return self._table.take(indices)
+
+        def spy_read_row_group(self, *args, **kwargs):
+            return TakeSpy(original_read_row_group(self, *args, **kwargs))
+
+        with mock.patch.object(pq.ParquetFile, 'read_row_group', autospec=True) as mocked_read:
+            mocked_read.side_effect = spy_read_row_group
+            # sample_rate=1 -> every one of the 1000 rows in the row group
+            # matches the sample boundary, but max_records=10 should mean
+            # take() is only ever called with 10 indices, not 1000.
+            rows = list(sample_row_iterator(self.parquet_file, sample_rate=1, max_records=10))
+
+        self.assertEqual(len(rows), 10)
+        self.assertEqual(take_call_sizes, [10])
+
     def test_empty_file(self):
         self.parquet_file = make_parquet_file(num_rows=0)
 


### PR DESCRIPTION
# Description of change
   Adds two functions to `singer_encodings.parquet`, alongside the existing `get_row_iterator()` (unchanged - still required for full syncs):               

   - `sample_row_iterator(file_like_handle, sample_rate=5, max_records=1000)` - filters rows at the Arrow level before converting them to Python objects, so sampling actually reduces memory usage instead of materializing full row groups first. Skips row groups with no sampled rows entirely, and stops once `max_records` is reached.                
   - `is_empty(file_like_handle)` - checks for zero rows using footer metadata            
     only, no decompression.                                                        

# Manual QA steps
   - `pytest tests/test_parquet.py`                                                       
   - Verified output matches the old post-hoc filtering approach for the same params      
   - Verified via mocked call counts that early-exit and row-group-skipping actually happe
 
# Risks
 - low, adds new functions and get_row_iterator()  used for full syncs is unchanged
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
